### PR TITLE
fix(http): avoid max retries cap by removing resty client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
-# Terraform
+# Terraform for in-directory testing
 .terraform
 terraform.tfstate
+crash.log

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/Paperspace/terraform-paperspace-provider
 
 require (
-	github.com/go-resty/resty/v2 v2.3.0
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
+	golang.org/x/net v0.0.0-20200513185701-a91f0712d120 // indirect
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
-github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -136,9 +136,8 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	defer resp.Body.Close()
-
 	LogResponse("GetMachine", resp, err)
+	defer resp.Body.Close()
 
 	if err != nil {
 		return nil, fmt.Errorf("Error sending GetMachine request: %s", err)
@@ -168,9 +167,8 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id *string, err error) 
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	defer resp.Body.Close()
-
 	LogResponse("CreateMachine", resp, err)
+	defer resp.Body.Close()
 
 	if err != nil {
 		return nil, fmt.Errorf("Error sending CreateMachine request: %s", err)
@@ -203,9 +201,8 @@ func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	defer resp.Body.Close()
-
 	LogResponse("DeleteMachine", resp, err)
+	defer resp.Body.Close()
 
 	if err != nil {
 		return fmt.Errorf("Error sending DeleteMachine request: %s", err)

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -70,7 +70,7 @@ func logHttpResponseObject(reqURL *url.URL, resp *http.Response, body map[string
 }
 
 // LogArrayResponse logs http response fields
-func LogArrayResponse(reqDesc string, reqURL *url.URL, resp *http.Response, body interface{}, err error) {
+func LogHttpResponseArray(reqDesc string, reqURL *url.URL, resp *http.Response, body interface{}, err error) {
 	log.Printf("Request: %v", reqDesc)
 	log.Printf("Request URL: %v", reqURL)
 	log.Printf("Response Status: %v", resp.Status)

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"reflect"
 	"time"
 
@@ -118,11 +119,12 @@ func (h withHeader) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // LogResponse logs http response fields
-func LogResponse(reqDesc string, resp *http.Response, err error) {
+func LogResponse(reqDesc string, reqURL *url.URL, resp *http.Response, err error) {
 	log.Printf("[INFO] Request: %v", reqDesc)
-	log.Printf("[INFO] Error: %v", err)
+	log.Printf("[INFO] Request URL: %v", reqURL)
 	log.Printf("[INFO] Response Status: %v", resp.Status)
 	log.Printf("[INFO] Response Body: %v", resp) // or resp.String() or string(resp.Body())
+	log.Printf("[INFO] Error: %v", err)
 }
 
 func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{}, err error) {
@@ -130,13 +132,12 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 	log.Printf("[INFO] paperspace GetMachine, url: %s", url)
 
 	req, err := http.NewRequest("GET", url, nil)
-
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing GetMachine request: %s", err)
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	LogResponse("GetMachine", resp, err)
+	LogResponse("GetMachine", req.URL, resp, err)
 	defer resp.Body.Close()
 
 	if err != nil {
@@ -167,7 +168,7 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id *string, err error) 
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	LogResponse("CreateMachine", resp, err)
+	LogResponse("CreateMachine", req.URL, resp, err)
 	defer resp.Body.Close()
 
 	if err != nil {
@@ -201,7 +202,7 @@ func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 	}
 
 	resp, err := psc.HttpClient.Do(req)
-	LogResponse("DeleteMachine", resp, err)
+	LogResponse("DeleteMachine", req.URL, resp, err)
 	defer resp.Body.Close()
 
 	if err != nil {

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -196,8 +196,29 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id *string, err error) 
 		return nil, fmt.Errorf("Error on CreateMachine: id not found")
 	}
 
-	log.Printf("[INFO] Success on CreateMachine: machine id: %v", id)
-
 	LogResponse("CreateMachine", resp, err)
 	return id, nil
+}
+
+func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
+	url := fmt.Sprintf("%s/machines/%s/destroyMachine", psc.APIHost, id)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("Error constructing DeleteMachine request: %s", err)
+	}
+
+	resp, err := psc.HttpClient.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		LogResponse("DeleteMachine", resp, err)
+		return fmt.Errorf("Error sending DeleteMachine request: %s", err)
+	}
+
+	if resp.StatusCode != 204 {
+		LogResponse("DeleteMachine", resp, err)
+		return fmt.Errorf("Error deleting machine: Response: %s", resp.Body)
+	}
+
+	LogResponse("DeleteMachine", resp, err)
+	return nil
 }

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -163,6 +163,11 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 
 	LogObjectResponse("GetMachine", req.URL, resp, body, err)
 
+	nextID, _ := body["id"].(string)
+	if nextID == "" {
+		return nil, fmt.Errorf("Error on GetMachine response: body missing id")
+	}
+
 	if resp.StatusCode == 404 {
 		return nil, nil
 	}

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -147,7 +147,7 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 
 	resp, err := psc.HttpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error sending GetMachine request: %s", err)
+		return nil, fmt.Errorf("Error completing GetMachine request: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -179,7 +179,7 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id string, err error) {
 
 	resp, err := psc.HttpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("Error sending CreateMachine request: %s", err)
+		return "", fmt.Errorf("Error completing CreateMachine request: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -213,7 +213,7 @@ func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 
 	resp, err := psc.HttpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("Error sending DeleteMachine request: %s", err)
+		return fmt.Errorf("Error completing DeleteMachine request: %s", err)
 	}
 	defer resp.Body.Close()
 

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -163,12 +163,8 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 	}
 
 	nextID, _ := body["id"].(string)
-	if nextID == "" {
-		return nil, fmt.Errorf("Error on GetMachine response: body missing id")
-	}
-
-	if resp.StatusCode == 404 {
-		return nil, nil
+	if resp.StatusCode == 404 || nextID == "" {
+		return nil, fmt.Errorf("Error on GetMachine: machine not found")
 	}
 
 	return body, nil
@@ -210,7 +206,7 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id string, err error) {
 
 func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 	url := fmt.Sprintf("%s/machines/%s/destroyMachine", psc.APIHost, id)
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing DeleteMachine request: %s", err)
 	}
@@ -221,13 +217,7 @@ func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 	}
 	defer resp.Body.Close()
 
-	body := make(map[string]interface{})
-	err = json.NewDecoder(resp.Body).Decode(&body)
-	if err != nil {
-		log.Printf("Error decoding DeleteMachine response body: %s", err)
-	}
-
-	LogObjectResponse("DeleteMachine", req.URL, resp, body, err)
+	LogObjectResponse("DeleteMachine", req.URL, resp, nil, err)
 
 	if resp.StatusCode != 204 {
 		return fmt.Errorf("Error deleting machine, statusCode: %d", resp.StatusCode)

--- a/src/terraform-provider-paperspace/client.go
+++ b/src/terraform-provider-paperspace/client.go
@@ -130,36 +130,33 @@ func (psc *PaperspaceClient) GetMachine(id string) (body map[string]interface{},
 	log.Printf("[INFO] paperspace GetMachine, url: %s", url)
 
 	req, err := http.NewRequest("GET", url, nil)
+
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing GetMachine request: %s", err)
 	}
 
 	resp, err := psc.HttpClient.Do(req)
 	defer resp.Body.Close()
+
+	LogResponse("GetMachine", resp, err)
+
 	if err != nil {
-		LogResponse("GetMachine", resp, err)
 		return nil, fmt.Errorf("Error sending GetMachine request: %s", err)
 	}
 
-	statusCode := resp.StatusCode
-
-	if statusCode != 404 && statusCode != 200 {
-		LogResponse("GetMachine", resp, err)
+	if resp.StatusCode != 404 && resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Error reading paperspace machine: Response: %s", body)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	if err != nil {
-		LogResponse("GetMachine", resp, err)
 		return nil, fmt.Errorf("Error decoding GetMachine response body: %s", err)
 	}
 
-	if statusCode == 404 {
-		LogResponse("GetMachine", resp, err)
+	if resp.StatusCode == 404 {
 		return nil, nil
 	}
 
-	LogResponse("GetMachine", resp, err)
 	return body, nil
 }
 
@@ -172,31 +169,29 @@ func (psc *PaperspaceClient) CreateMachine(data []byte) (id *string, err error) 
 
 	resp, err := psc.HttpClient.Do(req)
 	defer resp.Body.Close()
+
+	LogResponse("CreateMachine", resp, err)
+
 	if err != nil {
-		LogResponse("CreateMachine", resp, err)
 		return nil, fmt.Errorf("Error sending CreateMachine request: %s", err)
 	}
 
 	body := make(map[string]interface{})
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	if err != nil {
-		LogResponse("CreateMachine", resp, err)
 		return nil, fmt.Errorf("Error decoding CreateMachine response body: %s", err)
 	}
 
 	if resp.StatusCode != 200 {
-		LogResponse("CreateMachine", resp, err)
 		return nil, fmt.Errorf("Error on CreateMachine: Response: %s", body)
 	}
 
 	id, _ = body["id"].(*string)
 
 	if *id == "" {
-		LogResponse("CreateMachine", resp, err)
 		return nil, fmt.Errorf("Error on CreateMachine: id not found")
 	}
 
-	LogResponse("CreateMachine", resp, err)
 	return id, nil
 }
 
@@ -209,16 +204,16 @@ func (psc *PaperspaceClient) DeleteMachine(id string) (err error) {
 
 	resp, err := psc.HttpClient.Do(req)
 	defer resp.Body.Close()
+
+	LogResponse("DeleteMachine", resp, err)
+
 	if err != nil {
-		LogResponse("DeleteMachine", resp, err)
 		return fmt.Errorf("Error sending DeleteMachine request: %s", err)
 	}
 
 	if resp.StatusCode != 204 {
-		LogResponse("DeleteMachine", resp, err)
 		return fmt.Errorf("Error deleting machine: Response: %s", resp.Body)
 	}
 
-	LogResponse("DeleteMachine", resp, err)
 	return nil
 }

--- a/src/terraform-provider-paperspace/datasource_network.go
+++ b/src/terraform-provider-paperspace/datasource_network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace dataSourceNetworkRead Client ready")
 

--- a/src/terraform-provider-paperspace/datasource_network.go
+++ b/src/terraform-provider-paperspace/datasource_network.go
@@ -84,6 +84,7 @@ func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace network: %s", err)
 	}
+	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode
 	log.Printf("[INFO] paperspace dataSourceNetworkRead StatusCode: %v", statusCode)

--- a/src/terraform-provider-paperspace/datasource_network.go
+++ b/src/terraform-provider-paperspace/datasource_network.go
@@ -11,7 +11,7 @@ import (
 )
 
 func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace dataSourceNetworkRead Client ready")
 
@@ -74,13 +74,13 @@ func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error reading paperspace network: must specify query filter properties")
 	}
 
-	url := fmt.Sprintf("%s/networks/getNetworks%s", psc.APIHost, queryStr)
+	url := fmt.Sprintf("%s/networks/getNetworks%s", paperspaceClient.APIHost, queryStr)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing GetNetworks request: %s", err)
 	}
 
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace network: %s", err)
 	}

--- a/src/terraform-provider-paperspace/datasource_network.go
+++ b/src/terraform-provider-paperspace/datasource_network.go
@@ -100,7 +100,7 @@ func dataSourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error decoding GetNetworks response body: %s", err)
 	}
-	LogArrayResponse("paperspace dataSourceNetworkRead", req.URL, resp, f, err)
+	LogHttpResponseArray("paperspace dataSourceNetworkRead", req.URL, resp, f, err)
 
 	mpa := f.([]interface{})
 	if len(mpa) > 1 {

--- a/src/terraform-provider-paperspace/datasource_template.go
+++ b/src/terraform-provider-paperspace/datasource_template.go
@@ -108,7 +108,7 @@ func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error decoding GetTemplate response body: %s", err)
 	}
-	LogArrayResponse("paperspace dataSourceTemplateRead", req.URL, resp, f, err)
+	LogHttpResponseArray("paperspace dataSourceTemplateRead", req.URL, resp, f, err)
 
 	mpa := f.([]interface{})
 	if len(mpa) > 1 {

--- a/src/terraform-provider-paperspace/datasource_template.go
+++ b/src/terraform-provider-paperspace/datasource_template.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace dataSourceTemplateRead Client ready")
 

--- a/src/terraform-provider-paperspace/datasource_template.go
+++ b/src/terraform-provider-paperspace/datasource_template.go
@@ -92,6 +92,7 @@ func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace template: %s", err)
 	}
+	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode
 	log.Printf("[INFO] paperspace dataSourceTemplateRead StatusCode: %v", statusCode)

--- a/src/terraform-provider-paperspace/datasource_template.go
+++ b/src/terraform-provider-paperspace/datasource_template.go
@@ -11,7 +11,7 @@ import (
 )
 
 func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace dataSourceTemplateRead Client ready")
 
@@ -82,13 +82,13 @@ func dataSourceTemplateRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error reading paperspace template: must specify query filter properties")
 	}
 
-	url := fmt.Sprintf("%s/templates/getTemplates%s", psc.APIHost, queryStr)
+	url := fmt.Sprintf("%s/templates/getTemplates%s", paperspaceClient.APIHost, queryStr)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing GetTemplates request: %s", err)
 	}
 
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace template: %s", err)
 	}

--- a/src/terraform-provider-paperspace/datasource_user.go
+++ b/src/terraform-provider-paperspace/datasource_user.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace dataSourceUserRead Client ready")
 

--- a/src/terraform-provider-paperspace/datasource_user.go
+++ b/src/terraform-provider-paperspace/datasource_user.go
@@ -92,7 +92,7 @@ func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error decoding GetUsers response body: %s", err)
 	}
-	LogArrayResponse("paperspace dataSourceTemplateRead", req.URL, resp, f, err)
+	LogHttpResponseArray("paperspace dataSourceTemplateRead", req.URL, resp, f, err)
 
 	mpa := f.([]interface{})
 	if len(mpa) > 1 {

--- a/src/terraform-provider-paperspace/datasource_user.go
+++ b/src/terraform-provider-paperspace/datasource_user.go
@@ -11,7 +11,7 @@ import (
 )
 
 func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace dataSourceUserRead Client ready")
 
@@ -66,13 +66,13 @@ func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error reading paperspace user: must specify query filter properties")
 	}
 
-	url := fmt.Sprintf("%s/users/getUsers%s", psc.APIHost, queryStr)
+	url := fmt.Sprintf("%s/users/getUsers%s", paperspaceClient.APIHost, queryStr)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing GetUsers request: %s", err)
 	}
 
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace user: %s", err)
 	}

--- a/src/terraform-provider-paperspace/datasource_user.go
+++ b/src/terraform-provider-paperspace/datasource_user.go
@@ -76,6 +76,7 @@ func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace user: %s", err)
 	}
+	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode
 	log.Printf("[INFO] paperspace dataSourceUserRead StatusCode: %v", statusCode)

--- a/src/terraform-provider-paperspace/datasource_user.go
+++ b/src/terraform-provider-paperspace/datasource_user.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).HttpClient
+	psc := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace dataSourceUserRead Client ready")
 
@@ -65,27 +66,32 @@ func dataSourceUserRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("Error reading paperspace user: must specify query filter properties")
 	}
 
-	resp, err := client.R().
-		Get("/users/getUsers" + queryStr)
+	url := fmt.Sprintf("%s/users/getUsers%s", psc.APIHost, queryStr)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("Error constructing GetUsers request: %s", err)
+	}
+
+	resp, err := psc.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace user: %s", err)
 	}
 
-	statusCode := resp.StatusCode()
+	statusCode := resp.StatusCode
 	log.Printf("[INFO] paperspace dataSourceUserRead StatusCode: %v", statusCode)
-	LogResponse("paperspace dataSourceUserRead", resp, err)
 	if statusCode == 404 {
 		return fmt.Errorf("Error reading paperspace user: users not found")
 	}
 	if statusCode != 200 {
-		return fmt.Errorf("Error reading paperspace user: Response: %s", resp.Body())
+		return fmt.Errorf("Error reading paperspace user: Response: %s", resp.Body)
 	}
 
 	var f interface{}
-	err = json.Unmarshal(resp.Body(), &f)
+	err = json.NewDecoder(resp.Body).Decode(&f)
 	if err != nil {
-		return fmt.Errorf("Error unmarshalling paperspace user read response: %s", err)
+		return fmt.Errorf("Error decoding GetUsers response body: %s", err)
 	}
+	LogArrayResponse("paperspace dataSourceTemplateRead", req.URL, resp, f, err)
 
 	mpa := f.([]interface{})
 	if len(mpa) > 1 {

--- a/src/terraform-provider-paperspace/provider.go
+++ b/src/terraform-provider-paperspace/provider.go
@@ -70,14 +70,14 @@ func envDefaultFuncAllowMissingDefault(k string, d string) schema.SchemaDefaultF
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := Config{
-		ApiKey:  d.Get("api_key").(string),
-		ApiHost: d.Get("api_host").(string),
+	config := ClientConfig{
+		APIKey:  d.Get("api_key").(string),
+		APIHost: d.Get("api_host").(string),
 		Region:  d.Get("region").(string),
 	}
 
-	log.Printf("[INFO] paperspace provider api_key %v", config.ApiKey)
-	log.Printf("[INFO] paperspace provider api_host %v", config.ApiHost)
+	log.Printf("[INFO] paperspace provider api_key %v", config.APIKey)
+	log.Printf("[INFO] paperspace provider api_host %v", config.APIHost)
 	if config.Region != "" {
 		log.Printf("[INFO] paperspace provider region %v", config.Region)
 	}

--- a/src/terraform-provider-paperspace/resource_machine.go
+++ b/src/terraform-provider-paperspace/resource_machine.go
@@ -99,10 +99,9 @@ func resourceMachineRead(d *schema.ResourceData, m interface{}) error {
 
 	_, err := psc.GetMachine(d.Id())
 	if err != nil {
+		d.SetId("")
 		return err
 	}
-
-	d.SetId("")
 
 	mp := make(map[string]interface{})
 	SetResData(d, mp, "name")

--- a/src/terraform-provider-paperspace/resource_machine.go
+++ b/src/terraform-provider-paperspace/resource_machine.go
@@ -43,7 +43,6 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 	body.AppendAsIfSet(d, "notification_email", "notificationEmail")
 
 	data, _ := json.MarshalIndent(body, "", "  ")
-	log.Println(string(data))
 
 	id, err := paperspaceClient.CreateMachine(data)
 	if err != nil {

--- a/src/terraform-provider-paperspace/resource_machine.go
+++ b/src/terraform-provider-paperspace/resource_machine.go
@@ -50,9 +50,9 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		body, err := psc.GetMachine(*id)
+		body, err := psc.GetMachine(id)
 		if err != nil {
-			return resource.NonRetryableError(err)
+			return resource.RetryableError(err)
 		}
 
 		state, ok := body["state"].(string)
@@ -88,7 +88,7 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 		SetResDataFrom(d, body, "script_id", "scriptId")
 		SetResDataFrom(d, body, "dt_last_run", "dtLastRun")
 
-		d.SetId(*id)
+		d.SetId(id)
 
 		return resource.NonRetryableError(resourceMachineRead(d, m))
 	})

--- a/src/terraform-provider-paperspace/resource_machine.go
+++ b/src/terraform-provider-paperspace/resource_machine.go
@@ -12,7 +12,7 @@ import (
 )
 
 func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	region := m.(PaperspaceClient).Region
 	if r, ok := d.GetOk("region"); ok {
@@ -45,13 +45,13 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 	data, _ := json.MarshalIndent(body, "", "  ")
 	log.Println(string(data))
 
-	id, err := psc.CreateMachine(data)
+	id, err := paperspaceClient.CreateMachine(data)
 	if err != nil {
 		return err
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		body, err := psc.GetMachine(id)
+		body, err := paperspaceClient.GetMachine(id)
 		if err != nil {
 			return resource.RetryableError(err)
 		}
@@ -96,9 +96,9 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceMachineRead(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
-	_, err := psc.GetMachine(d.Id())
+	_, err := paperspaceClient.GetMachine(d.Id())
 	if err != nil {
 		d.SetId("")
 		return err
@@ -139,15 +139,15 @@ func resourceMachineUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceMachineDelete(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
-	err := psc.DeleteMachine(d.Id())
+	err := paperspaceClient.DeleteMachine(d.Id())
 	if err != nil {
 		return err
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		body, err := psc.GetMachine(d.Id())
+		body, err := paperspaceClient.GetMachine(d.Id())
 		log.Printf("\nbody: %v\nerr: %v", body, err)
 		if err != nil {
 			if strings.Contains(err.Error(), "machine not found") {

--- a/src/terraform-provider-paperspace/resource_script.go
+++ b/src/terraform-provider-paperspace/resource_script.go
@@ -9,7 +9,7 @@ import (
 )
 
 func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace resourceScriptCreate Client ready")
 
@@ -76,7 +76,7 @@ func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace resourceScriptRead Client ready")
 
@@ -125,7 +125,7 @@ func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
 	SetResDataFrom(d, mp, "is_enabled", "isEnabled")
 	SetResDataFrom(d, mp, "run_once", "runOnce")
 
-	client = m.(PaperspaceClient).RestyClient
+	client = m.(PaperspaceClient).HttpClient
 
 	resp, err = client.R().
 		Get("/scripts/getScriptText?scriptId=" + d.Id())
@@ -158,7 +158,7 @@ func resourceScriptUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScriptDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(PaperspaceClient).RestyClient
+	client := m.(PaperspaceClient).HttpClient
 
 	log.Printf("[INFO] paperspace resourceScriptDelete Client ready")
 

--- a/src/terraform-provider-paperspace/resource_script.go
+++ b/src/terraform-provider-paperspace/resource_script.go
@@ -11,7 +11,7 @@ import (
 )
 
 func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace resourceScriptCreate Client ready")
 
@@ -33,13 +33,13 @@ func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
 	data, _ := json.MarshalIndent(body, "", "  ")
 	log.Println(string(data))
 
-	url := fmt.Sprintf("%s/scripts/createScript", psc.APIHost)
+	url := fmt.Sprintf("%s/scripts/createScript", paperspaceClient.APIHost)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
 		return fmt.Errorf("Error constructing CreateScript request: %s", err)
 	}
 
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error creating paperspace script: %s", err)
 	}
@@ -81,17 +81,17 @@ func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace resourceScriptRead Client ready")
 
-	url := fmt.Sprintf("%s/scripts/getScript?scriptId=%s", psc.APIHost, d.Id())
+	url := fmt.Sprintf("%s/scripts/getScript?scriptId=%s", paperspaceClient.APIHost, d.Id())
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing GetScript request: %s", err)
 	}
 
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error completing GetScript request: %s", err)
 	}
@@ -135,13 +135,13 @@ func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
 	SetResDataFrom(d, mp, "is_enabled", "isEnabled")
 	SetResDataFrom(d, mp, "run_once", "runOnce")
 
-	url = fmt.Sprintf("%s/scripts/getScriptText?scriptId=%s", psc.APIHost, d.Id())
+	url = fmt.Sprintf("%s/scripts/getScriptText?scriptId=%s", paperspaceClient.APIHost, d.Id())
 	req, err = http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing GetScriptText request: %s", err)
 	}
 
-	resp, err = psc.HttpClient.Do(req)
+	resp, err = paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error reading paperspace script text: %s", err)
 	}
@@ -175,16 +175,16 @@ func resourceScriptUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceScriptDelete(d *schema.ResourceData, m interface{}) error {
-	psc := m.(PaperspaceClient)
+	paperspaceClient := m.(PaperspaceClient)
 
 	log.Printf("[INFO] paperspace resourceScriptDelete Client ready")
 
-	url := fmt.Sprintf("%s/scripts/%s/destroy", psc.APIHost, d.Id())
+	url := fmt.Sprintf("%s/scripts/%s/destroy", paperspaceClient.APIHost, d.Id())
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error constructing DeleteScript request: %s", err)
 	}
-	resp, err := psc.HttpClient.Do(req)
+	resp, err := paperspaceClient.HttpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error deleting paperspace script: %s", err)
 	}

--- a/src/terraform-provider-paperspace/resource_script.go
+++ b/src/terraform-provider-paperspace/resource_script.go
@@ -56,7 +56,7 @@ func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error decoding GetScript response body: %s", err)
 	}
-	LogArrayResponse("paperspace dataSourceGetScript", req.URL, resp, f, err)
+	LogHttpResponseArray("paperspace dataSourceGetScript", req.URL, resp, f, err)
 
 	mp := f.(map[string]interface{})
 	id, _ := mp["id"].(string)
@@ -106,7 +106,7 @@ func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
 	}
 	var body interface{}
 	json.NewDecoder(resp.Body).Decode(&body)
-	LogArrayResponse("paperspace resourceScriptCreate", req.URL, resp, body, err)
+	LogHttpResponseArray("paperspace resourceScriptCreate", req.URL, resp, body, err)
 
 	if statusCode != 200 {
 		return fmt.Errorf("Error reading paperspace script: Response: %s", body)
@@ -152,7 +152,7 @@ func resourceScriptRead(d *schema.ResourceData, m interface{}) error {
 
 	json.NewDecoder(resp.Body).Decode(&body)
 	s, err := json.Marshal(body)
-	LogArrayResponse("paperspace resourceScriptCreate", req.URL, resp, body, err)
+	LogHttpResponseArray("paperspace resourceScriptCreate", req.URL, resp, body, err)
 
 	if statusCode == 404 {
 		log.Printf("[INFO] paperspace resourceScriptRead text scriptId not found")
@@ -192,7 +192,7 @@ func resourceScriptDelete(d *schema.ResourceData, m interface{}) error {
 
 	statusCode := resp.StatusCode
 	log.Printf("[INFO] paperspace resourceScriptDelete StatusCode: %v", statusCode)
-	LogArrayResponse("paperspace resourceScriptDelete", req.URL, resp, nil, err)
+	LogHttpResponseArray("paperspace resourceScriptDelete", req.URL, resp, nil, err)
 	if statusCode != 204 && statusCode != 404 {
 		return fmt.Errorf("Error deleting paperspace script: Response: %s", resp.Body)
 	}


### PR DESCRIPTION
Though this PR involves a lot of refactoring, and could go further, it is strictly in service of https://paperspace.atlassian.net/browse/PS-13868, where we need to be able to provision _n_ machines in parallel and reliably. So I did not take it further than it clearly could go.

I have tested this manually multiple times from two different Terraform configurations with multiple machines and a script, by using `terraform apply` and `terraform destroy` successfully in all cases.

### The problem
The `resty` http client was producing a maddening bug where it would apparently and repeatably enforce had an implicit number of max retries, total connections, or something similar, at which point it would stop creating new requests successfully.

This was discovered when implementing wait/retry functionality for Paperspace machine provisioning. When trying to provision more than 1 machine, it would fail reliably and consistently at the same point, every time: it would stop making requests after  ~1m40s when trying to provision 2 or more machines, and Terraform would loop until the timeout was reached, when using the retry approach to wait for machines to actually enter a `ready` state.

With @paperspace-philip's help, we determined that it  was a Resty bug rather than a Terraform bug or a different Provider by process of elimination, but it wasn't clear where to go  from there, and there wasn't a strong case for keeping Resty; with this bug, multiple machines could _not_ be provisioned on Paperspace, and the bug happened in a reliable and consistent manner.

### The solution
Instead, this PR removes resty and instead introduces the use of the built in Go net/http client.

To make this cleaner, I refactored the client code for the `resourceMachine` code path in particular into SDK-like client helper functions per API endpoint.

I left the other data resources and script resource http inline, but also refactored them to use the built-in Go net/http client rather than resty.

I also cleaned up the logic, logging, and more.

### Further considerations
It would be best to:
1. factor the client out  from this provider altogether into a dedicated Paperspace Go SDK
1. remove the inline client logic from the remaining data and resource schemas
1. continue to extend the provider to cover more of Paperspace infrastructure
1. add tests

However, I would contend that these are out of the scope of simply getting wait/retry to actually work successfully for multiple machines, which was the primary purpose of this changeset.